### PR TITLE
Update dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,15 +43,14 @@ All files are moved to the Archive/.. folder for future reference.
 
 ###Executing the pipeline scripts
 
-The scripts that create the MARC files for conversion are located in the `ld4p-tracer-bullet-scripts` repository (https://github.com/sul-dlss/ld4p-tracer-bullet-scripts).
-Clone that repository and run the wrapper script:
+The scripts that create the MARC files for conversion are located in the
+[sul-dlss/ld4p-tracer-bullet-scripts](https://github.com/sul-dlss/ld4p-tracer-bullet-scripts)
+repository.  The instructions in that repository can be followed to run those scripts.
 
-```
-/s/SUL/Bin/LD4P/TB1/bin/do_pipeline.ksh
-```
-Then run `mvn exec:java`
 
-##Dependencies
+## Development
+
+### Dependencies
 
 - Java 8
 - Maven 3
@@ -113,25 +112,43 @@ credentials to maven settings.  Follow maven instructions to encrypt the passwor
     - https://books.sonatype.com/nexus-book/reference/_adding_credentials_to_your_maven_settings.html
 
 
-##Compiling and Executing the pre- and post-marc processing Java packages (and submitting code coverage data)
 
-Import the project into a Java IDE and use the provided iDE build tools. Don't forget to set the Maven property 
-`repoToken` to be the coveralls project repository token, using `-DrepoToken=yourcoverallsprojectrepositorytoken` in the 
-configuration section for the plugin in your IDE.
+### Compiling and Executing Conversions
 
-If you want to build the project and run the program from the command line:
+There are convenient wrapper scripts available from the
+[sul-dlss/ld4p-tracer-bullet-scripts](https://github.com/sul-dlss/ld4p-tracer-bullet-scripts)
+project.  To use those scripts, the artifacts of this project need to be
+downloaded or built from source.  To build this project, the
+[Apache Maven](https://maven.apache.org/) build
+tools must be available.
+
+To build and package the maven project (assuming maven is installed already):
 ```
+git clone https://github.com/sul-dlss/ld4p-tracer-bullets.git
+cd ld4p-tracer-bullets
 mvn package
-mvn exec:java
 ```
 
-There is also a packaged JAR with dependencies that should work outside of this project, e.g.
+The packaged JAR includes all dependencies, so it should work outside of this project.  The
+packaged JAR can be copied to a convenient location and used on the CLASSPATH or the command line, e.g.
 ```
 cp conversiontracerbullet/target/conversion-tracer-bullet-jar-with-dependencies.jar ~/lib/ld4p_conversion.jar
-java -cp ~/lib/ld4p_conversion.jar org.stanford.MarcToXML ./files/marc_file.mrc  ./files/mark_file.xml
+java -cp ~/lib/ld4p_conversion.jar org.stanford.MarcToXML ./files/marc_file.mrc ./files/mark_file.xml
 ```
 
-To run the tests and submit coverage report from the command line:
+
+### Code Coverage Reports
+
+To run the tests and view a coverage report from the command line:
+```
+mvn clean cobertura:cobertura
+ls -l target/site/cobertura/
+firefox target/site/cobertura/index.html
+```
+
+The [Travis CI](https://travis-ci.org/sul-dlss/ld4p-tracer-bullets) builds run tests and submit
+a coverage report to [Coveralls](https://coveralls.io/github/sul-dlss/ld4p-tracer-bullets).
+To update Coveralls from the command line, try:
 ```
 mvn clean test cobertura:cobertura coveralls:report -DrepoToken=yourcoverallsprojectrepositorytoken
 ```

--- a/conversiontracerbullet/pom.xml
+++ b/conversiontracerbullet/pom.xml
@@ -77,46 +77,51 @@
     </build>
 
     <dependencies>
+
+        <!--COMPILE/RUNTIME-->
+
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
             <version>2.7</version>
         </dependency>
-        <!-- https://mvnrepository.com/artifact/junit/junit -->
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.12</version>
-        </dependency>
         <!-- https://mvnrepository.com/artifact/org.marc4j/marc4j -->
         <dependency>
             <groupId>org.marc4j</groupId>
             <artifactId>marc4j</artifactId>
-            <version>2.7.3</version>
+            <version>2.8.0</version>
         </dependency>
-        <!-- https://mvnrepository.com/artifact/com.oracle/ojdbc14 -->
+        <!-- Symphony is running Oracle 11.2 -->
+        <!-- http://www.oracle.com/technetwork/apps-tech/jdbc-112010-090769.html -->
+        <!-- https://mvnrepository.com/artifact/com.oracle/ojdbc -->
         <dependency>
             <groupId>com.oracle.jdbc</groupId>
-            <artifactId>ojdbc7</artifactId>
-            <version>12.1.0.2</version>
+            <artifactId>ojdbc6</artifactId>
+            <version>11.2.0.4</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/net.sf.saxon/Saxon-HE -->
         <dependency>
             <groupId>net.sf.saxon</groupId>
             <artifactId>Saxon-HE</artifactId>
-            <version>9.4</version>
+            <version>9.7.0-14</version>
+        </dependency>
+
+        <!--TESTS-->
+
+        <!-- https://mvnrepository.com/artifact/junit/junit -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
+            <scope>test</scope>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.mockito/mockito-core -->
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-all</artifactId>
             <version>1.10.19</version>
-        </dependency>
-        <!-- https://mvnrepository.com/artifact/org.jdom/jdom2 -->
-        <dependency>
-            <groupId>org.jdom</groupId>
-            <artifactId>jdom2</artifactId>
-            <version>2.0.6</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
+
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -35,23 +35,6 @@
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>org.eluder.coveralls</groupId>
-                <artifactId>coveralls-maven-plugin</artifactId>
-                <version>4.3.0</version>
-            </plugin>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>cobertura-maven-plugin</artifactId>
-                <version>2.7</version>
-                <configuration>
-                    <format>xml</format>
-                    <maxmem>256m</maxmem>
-                    <!-- aggregated reports for multi-module projects -->
-                    <aggregate>true</aggregate>
-                    <check/>
-                </configuration>
-            </plugin>
-            <plugin>
                 <!-- UNIT TEST RUNNER -->
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
@@ -73,11 +56,11 @@
                     </execution>
                 </executions>
             </plugin>
-        </plugins>
-    </build>
-
-    <reporting>
-        <plugins>
+            <plugin>
+                <groupId>org.eluder.coveralls</groupId>
+                <artifactId>coveralls-maven-plugin</artifactId>
+                <version>4.3.0</version>
+            </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>cobertura-maven-plugin</artifactId>
@@ -85,13 +68,16 @@
                 <configuration>
                     <check/>
                     <formats>
-                        <format>html</format>
                         <format>xml</format>
+                        <format>html</format>
                     </formats>
+                    <maxmem>256m</maxmem>
+                    <!-- aggregated reports for multi-module projects -->
+                    <aggregate>true</aggregate>
                 </configuration>
             </plugin>
         </plugins>
-    </reporting>
+    </build>
 
     <dependencies>
         <!-- https://mvnrepository.com/artifact/org.codehaus.mojo/exec-maven-plugin -->


### PR DESCRIPTION
Maven dependencies
- grouped into `compile` and `test` dependencies
- the `test` dependencies should use the `<scope>test</scope>` so they are not packaged
- revised/updated some library versions
  - using Oracle JDBC 11.2.x because Symphony is running Oracle 11.2
  - should be OK although our test coverage is not complete yet so can't be sure about this
- removed the dependency on `org.jdom.jdom2` because it's not referenced by anything (AFAICT)

Code coverage revisions
- revised the configs for code coverage so they can generate both XML and HTML results
- the revised config generates HTML reports without having to create an entire `site` report
  - this provides easier code coverage reports for faster turnaround when creating unit tests
- README is updated on how to generate code coverage reports on laptop

README updates
- add links to other projects (mainly scripts)
- leave some details to the scripts project

Integration tests required to check these updates are working OK:
- [x] run a test MarcToXML conversion 
  - this was done on the auth-db-debug branch after rebasing it on this branch, because some MarcToXML bugs had to be fixed to test this.

