### PR TITLE
Mockito for unit tests

### DIFF
--- a/conversiontracerbullet/pom.xml
+++ b/conversiontracerbullet/pom.xml
@@ -125,22 +125,18 @@
             <version>2.3.0</version>
             <scope>test</scope>
         </dependency>
+        <!--https://github.com/powermock/powermock/wiki/Mockito_maven-->
         <dependency>
             <groupId>org.powermock</groupId>
             <artifactId>powermock-module-junit4</artifactId>
             <version>${powermock.version}</version>
             <scope>test</scope>
         </dependency>
+        <!--2017-02: pulls in org.mockito:mockito-core:jar:1.10.19:test-->
         <dependency>
             <groupId>org.powermock</groupId>
-            <artifactId>powermock-api-easymock</artifactId>
+            <artifactId>powermock-api-mockito</artifactId>
             <version>${powermock.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.easymock</groupId>
-            <artifactId>easymock</artifactId>
-            <version>3.4</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/conversiontracerbullet/src/test/java/org/stanford/AuthDBConnectionOpenTest.java
+++ b/conversiontracerbullet/src/test/java/org/stanford/AuthDBConnectionOpenTest.java
@@ -4,14 +4,12 @@ import oracle.jdbc.pool.OracleDataSource;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.sql.Connection;
-
-import static org.easymock.EasyMock.expect;
-import static org.powermock.api.easymock.PowerMock.createMock;
-import static org.powermock.api.easymock.PowerMock.replay;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({ AuthDBConnection.class })
@@ -25,10 +23,10 @@ public class AuthDBConnectionOpenTest {
     }
 
     private void createMocksAndSetExpectations() throws Exception {
-        Connection mockConnection = createMock(Connection.class);
-        OracleDataSource mockDS = createMock(OracleDataSource.class);
-        expect(mockDS.getConnection()).andReturn(mockConnection);
-        expect(new OracleDataSource()).andReturn(mockDS);
-        replay(OracleDataSource.class);
+        Connection mockConnection = PowerMockito.mock(Connection.class);
+        OracleDataSource mockDS = PowerMockito.mock(OracleDataSource.class);
+        Mockito.when(mockDS.getConnection()).thenReturn(mockConnection);
+        Mockito.when(new OracleDataSource()).thenReturn(mockDS);
+        PowerMockito.verifyStatic(); // default times is once
     }
 }


### PR DESCRIPTION
After checking with other DLSS developers, other java projects in the library dev community are using Mockito for unit test mocks and stubs.

Fix #77 

PS. `AuthDBConnectionOpenTest` is adapted to work with Mockito so it compiles and runs; it still needs to be ignored, it can be fixed later.