### PR TITLE
LOC XQuery converter requires older Saxon - try Saxon-HE-9.5.1-8

### DIFF
--- a/conversiontracerbullet/pom.xml
+++ b/conversiontracerbullet/pom.xml
@@ -108,7 +108,7 @@
         <dependency>
             <groupId>net.sf.saxon</groupId>
             <artifactId>Saxon-HE</artifactId>
-            <version>9.7.0-14</version>
+            <version>9.5.1-8</version>
         </dependency>
 
         <!--TESTS-->


### PR DESCRIPTION
Try to fix #79 - there is no code in this project, per se, that uses this library directly, but it is required by the LOC converter.  So this should have no impact on any java unit tests in this project.