### PR TITLE
pom.xml - remove compiler plugin at top level

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,14 +19,6 @@
         <finalName>${project.artifactId}</finalName>
         <plugins>
             <plugin>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.3.2</version>
-                <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
-                </configuration>
-            </plugin>
-            <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
                 <version>1.5.0</version>


### PR DESCRIPTION
The parent project has no code to compile, so removing the compiler plugin at this level.  The compiler plugin is defined in the converter module, where it belongs.

This commit is a prelude to using a branch that will compile for java 7, because the code is java 7 compatible and it can compile on java 7 (this can be verified using the `java-7` branch).  To enable this option to build for java-7, the compiler config in the converter module needs to be modified.  When it is modified, there are conflicts with the parent compiler plugin.  As it turns out, we don't need the parent compiler plugin at all, so let's remove it.

(Note, this is not a proposal or recommendation to use java 7.  This PR is only removing an extraneous/duplicate compiler plugin from the parent pom.xml file.)